### PR TITLE
fix: unsync audio after unmount

### DIFF
--- a/src/components/main/Machine.tsx
+++ b/src/components/main/Machine.tsx
@@ -442,7 +442,6 @@ const Machine = ({ isMenuOpen, isToneStarted }: MachineProps) => {
         playerRef.current[curSeq].fullPlayer.unsync()
         playerRef.current[curSeq].jamPlayer.unsync()
       }
-      
     }
   }, [isToneStarted]);
 

--- a/src/components/main/Machine.tsx
+++ b/src/components/main/Machine.tsx
@@ -437,6 +437,13 @@ const Machine = ({ isMenuOpen, isToneStarted }: MachineProps) => {
       //FX相關
       
     }
+    return () => {
+      if (playerRef.current) {
+        playerRef.current[curSeq].fullPlayer.unsync()
+        playerRef.current[curSeq].jamPlayer.unsync()
+      }
+      
+    }
   }, [isToneStarted]);
 
   return (


### PR DESCRIPTION
解決切換卡帶後，使用者點擊播放鈕，前一個卡帶的音檔仍會播放的問題