### PR TITLE
fix: load audio before starting and dispose audio after switching cassette

### DIFF
--- a/src/components/layout/Hint.tsx
+++ b/src/components/layout/Hint.tsx
@@ -31,8 +31,6 @@ const Hint = ({ showHint, setShowHint, setIsToneStarted }: HintProps) => {
           cursor="pointer"
           onClick={async () => {
             setShowHint(false);
-            await Tone.loaded();
-            console.log("Audio Ready");
             await Tone.start();
             console.log("Audio context started!");
 

--- a/src/recording.tsx
+++ b/src/recording.tsx
@@ -56,7 +56,11 @@ export default class Recording {
     this.hasRegion = false;
   }
 
-  cleanup() {
+  unsync() {
+    this.player?.unsync();
+  }
+
+  dispose() {
     this.ws?.destroy();
     this.player?.dispose();
   }


### PR DESCRIPTION
This PR fixes 
1. the error when switching cassette. This cause is that the audio is not loaded before called `Player.start()`
2. the bug where audio of the previous cassette is played after switching